### PR TITLE
Fixed BCFtools concat

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -22,18 +22,13 @@ bsub -q docker -o $output_dir/Clinvar_XML_Parser_full.out \
 -S $clinvar_refdir/$variant_summary \
 --output-path $output_dir'
 
-#Combine the multi and single-allele files into one big honking VCF
-bcftools concat -a -d all $output_dir/b37/multi/clinvar_alleles.multi.b37.vcf.gz \
+#Combine the multi and single-allele files into one big honking VCF.
+#Use -d none to remove the duplicate lines, since some alleles will apear in both lists.
+#DO NOT use -d all on this data, it will drop any subsequent alleles that share the same coordinates.
+bcftools concat -a -d none $output_dir/b37/multi/clinvar_alleles.multi.b37.vcf.gz \
 $output_dir/b37/single/clinvar_alleles.single.b37.vcf.gz \
 -o $output_dir/clinvar_alleles.combined.b37.vcf.gz
 
-#Remove the duplicate lines, since some alleles will apear in both lists:
-cd $output_dir/clinvar_alleles.combined.b37.vcf.gz
-grep "^#" clinvar_parsed_combined.b37.vcf > clinvar_parsed_combined.b37.unique.vcf && cat clinvar_parsed_combined.b37.vcf \
-| egrep -v '^#' \
-| sort \
-| uniq \
->> clinvar_parsed_combined.b37.unique.vcf
 
 bsub -P congenica -o $output_dir/ClinVar_Load_Log.out \
 -e $output_dir/ClinVar_Load_Log.err \

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -29,9 +29,10 @@ bcftools concat -a -d none $output_dir/b37/multi/clinvar_alleles.multi.b37.vcf.g
 $output_dir/b37/single/clinvar_alleles.single.b37.vcf.gz \
 -o $output_dir/clinvar_alleles.combined.b37.vcf.gz
 
+java -Xmx8g -Xms2g -jar /usr/local/software/picard/picard.jar SortVcf INPUT=clinvar_alleles.combined.b37.unique.vcf.gz OUTPUT=clinvar_alleles.combined.b37.unique.sorted.vcf.gz
 
 bsub -P congenica -o $output_dir/ClinVar_Load_Log.out \
 -e $output_dir/ClinVar_Load_Log.err \
 python ~/sapientia-web/pipeline/ruffus/load_curated_snv_list.py --verbose 3 --jobs 4 \
 --curated-variant-list $list_name --curated-variant-list-user $sapientia_user \
---no-qc --no-format-vcf --sample-vcf $output_dir/clinvar_alleles.combined.b37.vcf.gz
+--no-qc --no-format-vcf --pathogenicity_field SAPIENTIA_CLINSIG --sample-vcf $output_dir/clinvar_alleles.combined.b37.unique.sorted.vcf.gz


### PR DESCRIPTION
Changed the bcftools command from -d all to -none. This way only variants with the same position AND allele will be removed.
Also removed a redundant filtering step because -d should do this anyway.