### PR TITLE
clinvar_table_to_vcf.py now uses RSID as ID in VCF 

### DIFF
--- a/src/clinvar_table_to_vcf.py
+++ b/src/clinvar_table_to_vcf.py
@@ -86,7 +86,7 @@ def table_to_vcf(input_table_path):
         vcf_row = []
         vcf_row.append(table_row["chrom"])
         vcf_row.append(table_row["pos"])
-        vcf_row.append(table_row["hgvs_c"])  # ID
+        vcf_row.append(table_row["dbsnp"])  # ID
         vcf_row.append(table_row["ref"])
         vcf_row.append(table_row["alt"])
         vcf_row.append('.')  # QUAL


### PR DESCRIPTION
the default here is to use HGVS ID as the VCF file ID field. This breaks the pop-up info in Genoverse for Sapientia, as it expects the RSID as the name