### PR TITLE
SAP-12903: update description in vcf-validation header line

### DIFF
--- a/src/clinvar_table_to_vcf.py
+++ b/src/clinvar_table_to_vcf.py
@@ -82,7 +82,7 @@ def table_to_vcf(input_table_path, input_reference_genome, version):
             version_date.group('month')
         ))
 
-    print('##CONGENICA_VCF_VALIDATION=<ID=CLINVAR_MASTER_NUM_TOTAL_VARIANTS,VALUE={},DESCRIPTION="Number of variants '
+    print('##CONGENICA_VCF_VALIDATION=<ID=CLINVAR_MASTER_NUM_TOTAL_VARIANTS,VALUE={},DESCRIPTION="Total number of variants '
           'in VCF"'.format(t.shape[0]))
     print('##CURATED_VARIANT_LIST_INFO=<ID=VERSION,VALUE="{}",DESCRIPTION="Version of source data">'.format(version))
     print('##CURATED_VARIANT_LIST_INFO=<ID=DESCRIPTION,VALUE="ClinVar variants (SNVs and indels) in the {}-{} '


### PR DESCRIPTION
standardise description for *_MASTER_NUM_TOTAL_VARIANTS so that this is compatible with the header line generated in CreateCuratedVariantList (currently in sapientia-web) and reference-data-automation repo. This must be: "Total number of variants in VCF". A comment was added to the function generating the header.