### PR TITLE
SAP-11534: handle clnhgvs using measure set name

### DIFF
--- a/src/parse_clinvar_xml.py
+++ b/src/parse_clinvar_xml.py
@@ -313,6 +313,8 @@ def parse_clinvar_tree(handle, dest=sys.stdout, multi=None, verbose=True, genome
                 # find hgvs_c
                 if (attribute_type == 'HGVS, coding, RefSeq' and "c." in attribute_value):
                     current_row['clnhgvs'] = attribute_value
+                else:
+                    current_row['clnhgvs'] = var_name
 
                 # find hgvs_p
                 if (attribute_type == 'HGVS, protein, RefSeq' and "p." in attribute_value):

--- a/src/parse_clinvar_xml.py
+++ b/src/parse_clinvar_xml.py
@@ -313,7 +313,7 @@ def parse_clinvar_tree(handle, dest=sys.stdout, multi=None, verbose=True, genome
                 # find hgvs_c
                 if (attribute_type == 'HGVS, coding, RefSeq' and "c." in attribute_value):
                     current_row['clnhgvs'] = attribute_value
-                else:
+                elif "c." in var_name:
                     current_row['clnhgvs'] = var_name
 
                 # find hgvs_p


### PR DESCRIPTION
Relax the clnhgvs value-checking: Now accepts .g as well as .c
(as agreed with Eva, Ben)